### PR TITLE
Fix gpg error when installing packages from repos

### DIFF
--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -43,6 +43,10 @@ function run_script() {
 	fi
 }
 
+# Remove error when installing packages from repos:
+# gpg: Fatal: can't create directory '/root/.gnupg': No such file or directory
+mkdir -p /var/roothome
+
 # Install Fedora packages
 run_script "Installing Fedora packages" "/ctx/install-fedora-pkgs.sh"
 


### PR DESCRIPTION
Removes this error when installing packages from repos: `gpg: Fatal: can't create directory '/root/.gnupg': No such file or directory`