### PR TITLE
Remove date-only tag on images in workflows

### DIFF
--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -64,7 +64,7 @@ jobs:
           tags: |
             type=raw,value=testing
             type=raw,value=testing.{{date 'YYYYMMDD'}}
-            type=raw,value={{date 'YYYYMMDD'}}
+            # type=raw,value={{date 'YYYYMMDD'}}
             type=sha,enable=${{ github.event_name == 'pull_request' }}
             type=ref,event=pr
           labels: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
           tags: |
             type=raw,value=latest
             type=raw,value=latest.{{date 'YYYYMMDD'}}
-            type=raw,value={{date 'YYYYMMDD'}}
+            # type=raw,value={{date 'YYYYMMDD'}}
             type=sha,enable=${{ github.event_name == 'pull_request' }}
             type=ref,event=pr
           labels: |


### PR DESCRIPTION
Edit workflows to not add a date-only tag to images. 